### PR TITLE
Add install instructions to cmake rules

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -15,6 +15,6 @@ if ("${CMAKE_Fortran_COMPILER_ID}" MATCHES "GNU")
   endif()
 endif()
 
-install(TARGETS libyaml_interface fortran-yaml-c DESTINATION lib)
+install(TARGETS yaml libyaml_interface fortran-yaml-c DESTINATION lib)
 install(DIRECTORY ${CMAKE_BINARY_DIR}/modules DESTINATION .)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,3 +1,5 @@
+set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
+
 add_library(libyaml_interface libyaml_interface.c)
 target_link_libraries(libyaml_interface yaml)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -14,3 +14,7 @@ if ("${CMAKE_Fortran_COMPILER_ID}" MATCHES "GNU")
     target_compile_options(fortran-yaml-c PRIVATE -Wunused -fcheck=all)
   endif()
 endif()
+
+install(TARGETS libyaml_interface fortran-yaml-c DESTINATION lib)
+install(DIRECTORY ${CMAKE_BINARY_DIR}/modules DESTINATION .)
+


### PR DESCRIPTION
This PR adds the cmake ability to install the package. 

The following is now possible: 

```
cmake -DCMAKE_INSTALL_PREFIX=${INSTALL_DIR} -DBUILD_SHARED_LIBS=Yes ..
cmake --build .
cmake --install .
``` 

Afterward, `INSTALL_DIR` will contain:

```
INSTALL_DIR
├── lib
│   ├── libfortran-yaml-c.so
│   ├── liblibyaml_interface.so
│   └── libyaml.so
└── modules
    ├── fortran_yaml_c_interface.mod
    ├── fortran_yaml_c.mod
    └── fortran_yaml_c_types.mod
```