### PR TITLE
Improved YAML parse error message & scalar to integer/real conversion

### DIFF
--- a/src/fortran_yaml_c_types.f90
+++ b/src/fortran_yaml_c_types.f90
@@ -310,7 +310,7 @@ contains
 
     value = default
     read(self%string,*,iostat=ios) value
-    if (present(success)) success = (ios == 0)
+    if (present(success)) success = (ios == 0)  .and. (index(trim(adjustl(self%string)), " ") == 0)
   end function
 
   function scalar_to_real(self, default, success) result(value)
@@ -323,7 +323,7 @@ contains
 
     value = default
     read(self%string,*,iostat=ios) value
-    if (present(success)) success = (ios == 0)
+    if (present(success)) success = (ios == 0)  .and. (index(trim(adjustl(self%string)), " ") == 0)
   end function
 
   recursive subroutine node_set_path(self, path)

--- a/src/fortran_yaml_c_types.f90
+++ b/src/fortran_yaml_c_types.f90
@@ -276,22 +276,30 @@ contains
     logical, intent(in) :: default
     logical, optional, intent(out) :: success
     logical :: value
+    character(len=:), allocatable :: tmp_string
+    integer slen, tlen
+    integer, parameter :: clen = 20
 
-    character(len=20), parameter :: true_strings(*) = &
+    character(len=clen), parameter :: true_strings(*) = &
       ['true','True','TRUE', &
        'on  ','On  ','ON  ', &
        'y   ','Y   ','yes ','Yes ','YES ']
-    character(len=20), parameter :: false_strings(*) = &
+    character(len=clen), parameter :: false_strings(*) = &
       ["false","False",'FALSE', &
        'off  ','Off  ','OFF  ', &
        'n    ','N    ','no   ','No   ','NO   ']
 
+    slen = len(self%string)
+    tlen = max(clen,slen)
+    allocate(character(len=tlen) :: tmp_string)
+    tmp_string = self%string // repeat(' ', max(0, tlen-slen))
+
     value = default
-    
-    if (any(self%string == true_strings)) then
+
+    if (any(tmp_string == true_strings)) then
       value = .true.
       if (present(success)) success = .true.
-    elseif (any(self%string == false_strings)) then
+    elseif (any(tmp_string == false_strings)) then
       value = .false.
       if (present(success)) success = .true.
     else


### PR DESCRIPTION
Hi, thanks for the great tool — it works very well in our Fortran codebase.

While using your library, I found two minor points which could be further improved:

(1) **Formatting the error message in `LoadFile_c`:**

Currently, if `yaml_parser_load()` fails, the error string is generic and doesn’t contain 
row/column info, which makes debugging YAML input files harder.

I’ve implemented a simple logic, which gives structured, multi-line messages like:

`Parsing error:`

   `File         : input.yaml`
   `Row        : 12`
   `Column  : 8`
   `Message : did not find expected ',' or ']'`

(2) **Improvements to scalar value conversions (`scalar_to_real`, `scalar_to_integer`, `scalar_to_logical`):**

The `scalar_to_real` and `scalar_to_integer` functions previously returned the first number from 
whitespace-separated strings (e.g., "1.0 2.0" → 1.0) while incorrectly reporting `success = .true.`. 
This is now fixed: the function now checks for leftover characters after reading and returns 
`success = .truee.` only if the entire string was consumed.

The `scalar_to_logical` function used to compare `self%string` directly against a list of fixed-length 
reference values (`true_strings`, `false_strings`), most of which were space-padded to 20 characters. 
This failed when `self%string` was not padded (e.g., `'F'` ≠ `'F '`). 
The fix normalizes the input string length to match the reference list before comparison. 
This ensures correct matching for values such as `'F'`, `'T'`, `'yes'`, `'no'`, etc.

The change in the code is minimal and fully portable. 
Would you be open to adding something like this into the main repo?

Thanks again!

Roland