### PR TITLE
Update CMAKE_Fortran_MODULE_DIRECTORY: use CMAKE_INSTALL_INCLUDEDIR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,8 @@ project (FORTRAN_YAML_C VERSION "0.2.6" LANGUAGES C Fortran)
 include(FortranCInterface)
 FortranCInterface_VERIFY()
 
-set(CMAKE_Fortran_MODULE_DIRECTORY "${CMAKE_BINARY_DIR}/modules")
+include(GNUInstallDirs)
+set(CMAKE_Fortran_MODULE_DIRECTORY "${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_INCLUDEDIR}")
 
 option(DOWNLOAD_LIBYAML "If ON, then libyaml will be downloaded and 
 built." ON)


### PR DESCRIPTION
## Description

May I suggest using `CMAKE_INSTALL_INCLUDEDIR` (usually `include`) instead of `modules` for `CMAKE_Fortran_MODULE_DIRECTORY`? This aligns better with the industry standard.

I created this PR for `main` (because this is what I am pointing to), but happy to change to `dev`/`develop`.
